### PR TITLE
Fix create suggestions

### DIFF
--- a/proxy_app/httpd/handler/createSuggestion.go
+++ b/proxy_app/httpd/handler/createSuggestion.go
@@ -262,7 +262,7 @@ func createNextWorkstepOrFinalSuggestionRequestFromLatestTrustmeshEntry(
 	workstepType string) *types.NewSuggestionRequest {
 	return &types.NewSuggestionRequest{
 		WorkgroupId:                          uuid.FromStringOrNil(req.WorkgroupId),
-		Recipient:                            latestFeedbackTrustmeshEntry.SenderOrgId.String(),
+		Recipient:                            req.Recipient,
 		WorkstepType:                         workstepType,
 		BusinessObjectType:                   req.BusinessObjectType,
 		BusinessObjectId:                     req.BusinessObjectId,


### PR DESCRIPTION
When creating suggestions with `NEXTWORKSTEP` and `FINALWORKSTEP` the code acts a little bit strange in my opinion. The recipient of the new suggestion is taken form the latest trustmesh entry. Unfortunately, this prevents both parties from changing the workflow state. 

**For example**: Alice sends an initial suggestion to Bob. Bob accepts the message and sends a positive feedback. Now both parties have a latest trustmesh entry with Sender=Bob. If Bob now wants to execute the next workstep and sends a suggestion with workstep type `NEXTWORKSTEP` or `FINALWORKSTEP`, the code will send the suggestion to Bob.

I have fixed this issue by taking the recipient from the DTO instead from the latest trustmesh entry.